### PR TITLE
feat: support helper lookup for Storage.store

### DIFF
--- a/src/BuiltinHelper.js
+++ b/src/BuiltinHelper.js
@@ -1,7 +1,5 @@
 const md5 = require('js-md5');
 
-const log = require('./log');
-
 const Asset = require('./Asset');
 const AssetType = require('./AssetType');
 const DataFormat = require('./DataFormat');
@@ -94,33 +92,6 @@ class BuiltinHelper extends Helper {
         return asset;
     }
 
-    /**
-     * Alias for store (old name of store)
-     * @deprecated Use BuiltinHelper.store
-     * @param {AssetType} assetType - The type of the asset to cache.
-     * @param {DataFormat} dataFormat - The dataFormat of the data for the cached asset.
-     * @param {Buffer} data - The data for the cached asset.
-     * @param {string} id - The id for the cached asset.
-     * @returns {string} The calculated id of the cached asset, or the supplied id if the asset is mutable.
-     */
-    cache (assetType, dataFormat, data, id) {
-        log.warn('Deprecation: BuiltinHelper.cache has been replaced with BuiltinHelper.store.');
-        return this.store(assetType, dataFormat, data, id);
-    }
-
-    /**
-     * Deprecated external API for _store
-     * @deprecated Not for external use. Create assets and keep track of them outside of the storage instance.
-     * @param {AssetType} assetType - The type of the asset to cache.
-     * @param {DataFormat} dataFormat - The dataFormat of the data for the cached asset.
-     * @param {Buffer} data - The data for the cached asset.
-     * @param {(string|number)} id - The id for the cached asset.
-     * @returns {string} The calculated id of the cached asset, or the supplied id if the asset is mutable.
-     */
-    store (assetType, dataFormat, data, id) {
-        log.warn('Deprecation: use Storage.createAsset. BuiltinHelper is for internal use only.');
-        return this._store(assetType, dataFormat, data, id);
-    }
 
     /**
      * Cache an asset for future lookups by ID.

--- a/src/Helper.js
+++ b/src/Helper.js
@@ -17,6 +17,20 @@ class Helper {
     load (assetType, assetId, dataFormat) {
         return Promise.reject(new Error(`No asset of type ${assetType} for ID ${assetId} with format ${dataFormat}`));
     }
+
+    /**
+     * Create or update an asset with provided data. The create function is called if no asset id is provided
+     * @param {AssetType} assetType - The type of asset to create or update.
+     * @param {?DataFormat} dataFormat - DataFormat of the data for the stored asset.
+     * @param {Buffer} data - The data for the cached asset.
+     * @param {?string} assetId - The ID of the asset to fetch: a project ID, MD5, etc.
+     * @return {Promise.<object>} A promise for the response from the create or update request
+     */
+    store (assetType, dataFormat, data, assetId) {
+        return Promise.reject(
+            new Error(`Cannot store asset of type ${assetType} for ID ${assetId} with format ${dataFormat}`)
+        );
+    }
 }
 
 module.exports = Helper;

--- a/src/WebHelper.js
+++ b/src/WebHelper.js
@@ -99,6 +99,10 @@ class WebHelper extends Helper {
 
         let storeIndex = 0;
         const tryNextSource = () => {
+            if (storeIndex >= stores.length) {
+                return Promise.resolve(null);
+            }
+
             const store = stores[storeIndex++];
 
             /** @type {UrlFunction} */


### PR DESCRIPTION
Adds support for using the helper list as storage as well as loading.
Removes deprecated store from BuiltinHelper, this prevents it being
used as part of storage for the helper list.